### PR TITLE
refactor(hook): change useOutsideClick

### DIFF
--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -2,29 +2,26 @@ import { useEffect } from 'react';
 
 export default function useOutsideClick(
   ref: React.RefObject<HTMLDivElement>,
-  func: () => void,
-  isOpen: boolean
+  handler: () => void,
+  isActive: boolean
 ): void {
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (!isOpen) {
-        return;
-      }
+    if (!isActive) {
+      return undefined;
+    }
 
-      if (
-        isOpen &&
-        e.target instanceof Node &&
-        ref.current &&
-        !ref.current.contains(e.target)
-      ) {
-        func();
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+
+      if (!ref.current?.contains(target)) {
+        handler();
       }
     };
 
-    document.addEventListener('click', handleClick, { capture: true });
+    document.addEventListener('mousedown', handleClick, { capture: true });
 
     return () => {
-      document.removeEventListener('click', handleClick, { capture: true });
+      document.removeEventListener('mousedown', handleClick, { capture: true });
     };
-  }, [func, isOpen, ref]);
+  }, [handler, isActive, ref]);
 }


### PR DESCRIPTION
Make the target a separate variable.
Rename the input function.
Change the event to mouse down.

Close #51